### PR TITLE
Add projectType configuration to options.yaml

### DIFF
--- a/RedbookApi/src/main/config/options.yaml
+++ b/RedbookApi/src/main/config/options.yaml
@@ -1,3 +1,4 @@
+projectType: requester
 language: COBOL
 requesterPrefix: RBK
 requesterExtension: cpy


### PR DESCRIPTION
# Summary

This pull request adds a project type configuration to the options file, explicitly defining this project as a "requester" type.

# Files Changed

📄 `RedbookApi/src/main/config/options.yaml`

Added a new `projectType` configuration field set to "requester" at the top of the configuration file. This explicitly declares the project type, which may be used by build tools or runtime configuration to determine how the project should be processed or deployed.